### PR TITLE
Dates to iso 8601

### DIFF
--- a/docs/3_Data_Specification/3_1_Base_Materials.md
+++ b/docs/3_Data_Specification/3_1_Base_Materials.md
@@ -19,7 +19,7 @@ The base materials schema contains information regarding the core materials. The
 |certificationClaims|`recommended`|List|The information regarding the certification. The entries should be the [Certification Claims Relationship List](../6_Relationship_Lists/6_005_Certification_Claims.md) identifiers.|
 |manufacturers|`recommended`|List|The information regarding the manufacturer(s). The entries should be the [Organisations Relationship List](../6_Relationship_Lists/6_010_Organisations.md) identifiers.|
 |manufacturedCountry|`recommended`|Numeric|The country the component was manufactured in. Use the country numeric [ISO codes](https://www.iban.com/country-codes){target=_blank} as described in the ISO 3166 international standard.|
-|updateDate|`required`|String|The date that the base material was provided/last updated. Use the format `dd/mm/yyyy`.|
+|updateDate|`required`|Date|The date that the base material was provided/last updated. Use the format `yyyy-mm-dd` adhering to the [ISO 8601 dateTime standard](https://www.iso.org/iso-8601-date-and-time-format.html).|
 
 ## Diagram
 
@@ -35,7 +35,7 @@ erDiagram
     certificationClaims List
     manufacturers List
     manufacturedCountry Numeric
-    updateDate String
+    updateDate Date
   }
   BASE_MATERIALS }o..o{ CONTROLLED_LISTS : attributes
   BASE_MATERIALS }o--o{ MATERIALS : material_constituents
@@ -71,10 +71,10 @@ Base materials should be provided as a separate csv file. The specification of t
         },
       "certification": "TRUE",
       "certificationClaims": ["1","35"],
-      "certificationDate": "01/08/2022",
+      "certificationDate": "2022-08-01",
       "manufacturers": [""],
       "manufacturedCountry": 724,
-      "updateDate": "01/08/2022",
+      "updateDate": "2022-08-01",
     }
     ```
 === "JSON #2"
@@ -101,14 +101,14 @@ Base materials should be provided as a separate csv file. The specification of t
           "category":"FSA",
           "detailed":"The Food Standards Agency (FSA) is the independent government department working to protect public health and consumers’ wider interests in relation to food in England, Wales and Northern Ireland."
         },
-        "certificationDate": "01/08/2022",
+        "certificationDate": "2022-08-01",
       }],
       "manufacturers": [""],
       "manufacturedCountry": {
         "Country": "United Kingdom of Great Britain and Northern Ireland (the)",
         "Numeric": 826
       },
-      "updateDate": "01/08/2022",
+      "updateDate": "2022-08-01",
     }
     ```
 === "CSV download"

--- a/docs/3_Data_Specification/3_2_Materials.md
+++ b/docs/3_Data_Specification/3_2_Materials.md
@@ -19,12 +19,12 @@ The materials schema contains information regarding the materials that are used 
 |areaDensityUnit|`recommended`|String|Either `gsm` or `m^2/kg` to describe the area density unit of measure.|
 |areaDensityTolerance|`recommended`|Numeric|The threshold of area density that the material can vary by. This is given as a +/- value.|
 |areaDensityToleranceType|`recommended`|String|Either `unit` or `percentage` based on the value provided in `areaDensityTolerance`. Where `unit` is equal to the value provided in `areaDensityUnit`.|
-|areaDensityDate|`recommended`|String|The date that the area density was last verified/measured. Use the format `dd/mm/yyyy`.|
+|areaDensityDate|`recommended`|Date|The date that the area density was last verified/measured. Use the format `yyyy-mm-dd` adhering to the [ISO 8601 dateTime standard](https://www.iso.org/iso-8601-date-and-time-format.html).|
 |certification|`recommended`|Boolean|Does the material have a certificate (e.g. FSC, REACH, FSA etc.)? Answer as: `TRUE` for yes and `FALSE` for no.|
 |certificationClaims|`recommended`|List|The information regarding the certification. The entries should be the [Certification Claims Relationship List](../6_Relationship_Lists/6_005_Certification_Claims.md) identifiers.|
 |manufacturers|`recommended`|List|The information regarding the manufacturer(s). The entries should be the [Organisations Relationship List](../6_Relationship_Lists/6_010_Organisations.md) identifiers.|
 |manufacturedCountry|`recommended`|Numeric|The country the component was manufactured in. Use the country numeric [ISO codes](https://www.iban.com/country-codes){target=_blank} as described in the ISO 3166 international standard.|
-|updateDate|`required`|String|The date that the material was provided/last updated. Use the format `dd/mm/yyyy`.|
+|updateDate|`required`|Date|The date that the material was provided/last updated. Use the format `yyyy-mm-dd` adhering to the [ISO 8601 dateTime standard](https://www.iso.org/iso-8601-date-and-time-format.html).|
 
 ## Diagram
 
@@ -41,12 +41,12 @@ BASE_MATERIALS }o--o{ MATERIALS : material_constituents
     areaDensityUnit String
     areaDensityTolerance Numeric
     areaDensityToleranceType String
-    areaDensityDate String
+    areaDensityDate Date
     certification Boolean
     certificationClaims List
     manufacturers List
     manufacturedCountry Numeric
-    updateDate String
+    updateDate Date
   }
   MATERIALS }o..o{ CONTROLLED_LISTS : attributes
   MATERIALS }o--o{ COMPONENTS : component_constituents
@@ -83,12 +83,12 @@ Materials should be provided as a separate csv file. The specification of this c
       "areaDensityUnit": "gsm",
       "areaDensityTolerance": "3.3",
       "areaDensityToleranceType": "percentage",
-      "areaDensityDate": "01/08/2022",
+      "areaDensityDate": "2022-08-01",
       "certification": "TRUE",
       "certificationClaims": ["1"],
       "manufacturers": [""],
       "manufacturedCountry": 826,
-      "updateDate": "01/08/2022",
+      "updateDate": "2022-08-01",
     }
     ```
 === "JSON #2"
@@ -124,7 +124,7 @@ Materials should be provided as a separate csv file. The specification of this c
               "Country": "United Kingdom of Great Britain and Northern Ireland (the)",
               "Numeric": 826
             },
-            "updateDate": "01/08/2022",
+            "updateDate": "2022-08-01",
           },
           "materialPurpose": {
             "identifier": "m-material-purpose-0005",
@@ -168,7 +168,7 @@ Materials should be provided as a separate csv file. The specification of this c
               "Country": "United Kingdom of Great Britain and Northern Ireland (the)",
               "Numeric": 826
             },
-            "updateDate": "01/08/2022",
+            "updateDate": "2022-08-01",
           },
           "materialPurpose": {
             "identifier": "m-material-purpose-0002",
@@ -212,7 +212,7 @@ Materials should be provided as a separate csv file. The specification of this c
               "Country": "United Kingdom of Great Britain and Northern Ireland (the)",
               "Numeric": 826
             },
-            "updateDate": "01/08/2022",
+            "updateDate": "2022-08-01",
           },
           "materialPurpose": {
             "identifier": "m-material-purpose-0002",
@@ -256,7 +256,7 @@ Materials should be provided as a separate csv file. The specification of this c
               "Country": "United Kingdom of Great Britain and Northern Ireland (the)",
               "Numeric": 826
             },
-            "updateDate": "01/08/2022",
+            "updateDate": "2022-08-01",
           },
           "materialPurpose": {
             "identifier": "m-material-purpose-0005",
@@ -277,7 +277,7 @@ Materials should be provided as a separate csv file. The specification of this c
       "areaDensity": "gsm",
       "areaDensityTolerance": "6",
       "areaDensityToleranceType": "unit",
-      "areaDensityDate": "01/08/2022",
+      "areaDensityDate": "2022-08-01",
       "certification": "FALSE",
       "certificationClaims": null,
       "manufacturers": [""],
@@ -285,7 +285,7 @@ Materials should be provided as a separate csv file. The specification of this c
         "Country": "United Kingdom of Great Britain and Northern Ireland (the)",
         "Numeric": 826
       },
-      "updateDate": "01/08/2022"
+      "updateDate": "2022-08-01"
     }
     ```
 === "CSV download"

--- a/docs/3_Data_Specification/3_3_Components.md
+++ b/docs/3_Data_Specification/3_3_Components.md
@@ -18,17 +18,17 @@ The components schema contains information regarding the individual components t
 |LOWcode|`recommended`|String|The list of waste code for **only** the component, by itself. LOW code is synonymous with European Waste Catalogue Code (EWC). For example: an empty bottle would have a LOWcode of `15 01 02`. Please use [Dsposal](https://dsposal.uk/browse/ewc) or [legislation.gov](https://www.legislation.gov.uk/uksi/2005/895/schedule/1/made) to find the LOWcode. **Note**: The LOWcode can based on its combination with other components and the actual product contained in the completePackaging. Be sure to only include the component LOWcode. If you cannot find the code or are uncertain please enter `Uncertain`.|
 |componentConstituents|`required`|List|The information regarding the consituents that are combined to create this component. The entries should be from the [Component Constituents Relationship List](../6_Relationship_Lists/6_002_Component_Constituents.md) identifier.|
 |height|`recommended`|Numeric|The height of the component. Please see the guidelines below on how to properly measure and report the height.|
-|heightDate|`recommended`|String|The date that the height was last verified/measured. Use the format `dd/mm/yyyy`.|
+|heightDate|`recommended`|Date|The date that the height was last verified/measured. Use the format `yyyy-mm-dd` adhering to the [ISO 8601 dateTime standard](https://www.iso.org/iso-8601-date-and-time-format.html).|
 |width|`recommended`|Numeric|The width of the component. Please see the guidelines below on how to properly measure and report the width.|
-|widthDate|`recommended`|String|The date that the width was last verified/measured. Use the format `dd/mm/yyyy`.|
+|widthDate|`recommended`|Date|The date that the width was last verified/measured. Use the format `yyyy-mm-dd` adhering to the [ISO 8601 dateTime standard](https://www.iso.org/iso-8601-date-and-time-format.html).|
 |depth|`recommended`|Numeric|The depth of the component. Please see the guidelines below on how to properly measure and report the depth.|
-|depthDate|`recommended`|String|The date that the depth was last verified/measured. Use the format `dd/mm/yyyy`.|
+|depthDate|`recommended`|Date|The date that the depth was last verified/measured. Use the format `yyyy-mm-dd` adhering to the [ISO 8601 dateTime standard](https://www.iso.org/iso-8601-date-and-time-format.html).|
 |volume|`recommended`|Numeric|The amount of space the component takes up. Note: this is related to the size of the component and is different to capacity. Using the height, width, and depth found using the measurement guidelines, calculate the component’s volume using: `height x width x depth`.|
-|volumeDate|`recommended`|String|The date that the volume was last verified/measured. Use the format `dd/mm/yyyy`.|
+|volumeDate|`recommended`|Date|The date that the volume was last verified/measured. Use the format `yyyy-mm-dd` adhering to the [ISO 8601 dateTime standard](https://www.iso.org/iso-8601-date-and-time-format.html).|
 |weight|`required`|Numeric|The weight of the component.|
 |weightTolerance|`required`|Numeric|The threshold of weight that components can vary by. This is given as +/- x%.|
 |weightToleranceType|`required`|String|Either `grams` or `percentage` based on the value provided in `weightTolerance`|
-|weightDate|`recommended`|String|The date that the weight was last verified/measured. Use the format `dd/mm/yyyy`.|
+|weightDate|`recommended`|Date|The date that the weight was last verified/measured. Use the format `yyyy-mm-dd` adhering to the [ISO 8601 dateTime standard](https://www.iso.org/iso-8601-date-and-time-format.html).|
 |shape|`recommended`|String|What is the shape of the component? The entry should contain the [shape controlled list](../5_Controlled_Lists/5_006_Shape.md) identifier for the component.|
 |function|`recommended`|String|What is the function of the component? The entry should contain the [function controlled list](../5_Controlled_Lists/5_004_Function.md) identifier for the component.|
 |flexibility|`recommended`|String|Whether the component is considered flexible or rigid. The entry should be the [flexibility controlled list](../5_Controlled_Lists/5_007_Flexibility.md) identifier.|
@@ -47,9 +47,9 @@ The components schema contains information regarding the individual components t
 |certificationClaims|`recommended`|List|The information regarding the certifications. The entries should be the [certification claims relationship list](../6_Relationship_Lists/6_005_Certification_Claims.md) identifiers.|
 |manufacturers|`recommended`|List|The information regarding the manufacturer(s). The entries should be the [Organisations Relationship List](../6_Relationship_Lists/6_010_Organisations.md) identifiers.|
 |manufacturedCountry|`recommended`|Numeric|The country the component was manufactured in. Use the country numeric [ISO codes](https://www.iban.com/country-codes){target=_blank} as described in the ISO 3166 international standard.|
-|updateDate|`required`|String|The date that the component was provided/last updated. Use the format `dd/mm/yyyy`.|
-|releaseDate|`recommended`|String|The date that the component will be available to use. Use the format `dd/mm/yyyy`.|
-|discontinueDate|`recommended`|String|The date that the component will no longer be available to use. Use the format `dd/mm/yyyy`.|
+|updateDate|`required`|Date|The date that the component was provided/last updated. Use the format `yyyy-mm-dd` adhering to the [ISO 8601 dateTime standard](https://www.iso.org/iso-8601-date-and-time-format.html).|
+|releaseDate|`recommended`|Date|The date that the component will be available to use. Use the format `yyyy-mm-dd` adhering to the [ISO 8601 dateTime standard](https://www.iso.org/iso-8601-date-and-time-format.html).|
+|discontinueDate|`recommended`|Date|The date that the component will no longer be available to use. Use the format `yyyy-mm-dd` adhering to the [ISO 8601 dateTime standard](https://www.iso.org/iso-8601-date-and-time-format.html).|
 
 ## Diagram
 
@@ -65,16 +65,16 @@ MATERIALS }o--o{ COMPONENTS : component_constituents
     LOWcode String
     componentConstituents List
     height Numeric
-    heightDate String
+    heightDate Date
     width Numeric
-    widthDate String
+    widthDate Date
     depth Numeric
-    depthDate String
+    depthDate Date
     volume Numeric
-    volumeDate String
+    volumeDate Date
     weight Numeric
     weightTolerance Numeric
-    weightDate String
+    weightDate Date
     shape String
     function String
     flexibility String
@@ -93,9 +93,9 @@ MATERIALS }o--o{ COMPONENTS : component_constituents
     partOfMultipack Boolean
     certification Boolean
     certificationClaims List
-    updateDate String
-    releaseDate String
-    discontinueDate String
+    updateDate Date
+    releaseDate Date
+    discontinueDate Date
   }
   COMPONENTS }o..o{ CONTROLLED_LISTS : attributes
   COMPONENTS }o..o{ RELATIONSHIP_LISTS : attributes
@@ -147,17 +147,17 @@ Components should be provided as a separate csv file. The specification of this 
             "DCEE1F88-A83B-5BBC-D2D9-6A862B344977"
         ],
         "height": 50,
-        "heightDate": "01/08/2022",
+        "heightDate": "2022-08-01",
         "width": 220,
-        "widthDate": "01/08/2022",
+        "widthDate": "2022-08-01",
         "depth": 170,
-        "depthDate": "01/08/2022",
+        "depthDate": "2022-08-01",
         "volume": 1870,
-        "volumeDate": "01/08/2022",
+        "volumeDate": "2022-08-01",
         "weight": 23,
         "weightTolerance": 1.5,
         "weightToleranceType": "grams",
-        "weightDate": "01/08/2022",
+        "weightDate": "2022-08-01",
         "shape": "c-shape-0004",
         "function": "function-0041",
         "flexibility": "c-flexibility-0002",
@@ -186,8 +186,8 @@ Components should be provided as a separate csv file. The specification of this 
         ],
         "manufacturers": [""],
         "manufacturedCountry": 372,
-        "updateDate": "01/08/2022",
-        "releaseDate": "01/08/2022",
+        "updateDate": "2022-08-01",
+        "releaseDate": "2022-08-01",
         "discontinueDate": ""
     }
     ```

--- a/docs/3_Data_Specification/3_4_Complete_Packaging.md
+++ b/docs/3_Data_Specification/3_4_Complete_Packaging.md
@@ -26,27 +26,27 @@ The complete packaging schema contains information regarding the complete packag
 |recyclability|`recommended`|Boolean|Is the complete packaging recyclable (as determined by a reputable source)? Answer as: `TRUE` for yes and `FALSE` for no.|
 |recyclabilityClaims|`recommended`|List|The information regarding this recyclability claims. The entries should be the [recyclability claims relationship list](../6_Relationship_Lists/6_006_Recyclability_Claims.md) identifiers.|
 |height|`recommended`|Numeric|The height of the complete packaging. Please see the guidelines below on how to properly measure and report the height.|
-|heightDate|`recommended`|String|The date that the height was last verified/measured. Use the format `dd/mm/yyyy`.|
+|heightDate|`recommended`|Date|The date that the height was last verified/measured. Use the format `yyyy-mm-dd` adhering to the [ISO 8601 dateTime standard](https://www.iso.org/iso-8601-date-and-time-format.html).|
 |width|`recommended`|Numeric|The width of the complete packaging. Please see the guidelines below on how to properly measure and report the width.|
-|widthDate|`recommended`|String|The date that the width was last verified/measured. Use the format `dd/mm/yyyy`.|
+|widthDate|`recommended`|Date|The date that the width was last verified/measured. Use the format `yyyy-mm-dd` adhering to the [ISO 8601 dateTime standard](https://www.iso.org/iso-8601-date-and-time-format.html).|
 |depth|`recommended`|Numeric|The depth of the complete packaging. Please see the guidelines below on how to properly measure and report the depth.|
-|depthDate|`recommended`|String|The date that the depth was last verified/measured. Use the format `dd/mm/yyyy`.|
+|depthDate|`recommended`|Date|The date that the depth was last verified/measured. Use the format `yyyy-mm-dd` adhering to the [ISO 8601 dateTime standard](https://www.iso.org/iso-8601-date-and-time-format.html).|
 |volume|`recommended`|Numeric|Using the height, width, and depth found using the measurement guidelines, calculate the complete packaging's volume using: `height x width x depth`.|
-|volumeDate|`recommended`|String|The date that the volume was last verified/measured. Use the format `dd/mm/yyyy`.|
+|volumeDate|`recommended`|Date|The date that the volume was last verified/measured. Use the format `yyyy-mm-dd` adhering to the [ISO 8601 dateTime standard](https://www.iso.org/iso-8601-date-and-time-format.html).|
 |weight|`required`|Numeric|The weight of the complete packaging.|
 |weightTolerance|`required`|Numeric|The threshold of weight that complete packaging can vary by. This can be given in grams or percentage.|
 |weightToleranceType|`required`|String|Either `grams` or `percentage` based on the value provided in `weightTolerance`|
-|weightDate|`recommended`|String|The date that the weight was last verified/measured. Use the format `dd/mm/yyyy`.|
+|weightDate|`recommended`|Date|The date that the weight was last verified/measured. Use the format `yyyy-mm-dd` adhering to the [ISO 8601 dateTime standard](https://www.iso.org/iso-8601-date-and-time-format.html).|
 |servingCapacity|`recommended`|Numeric|The serving capacity of the complete packaging - how much of a product that can be contained in the complete packaging.|
-|servingCapacityDate|`recommended`|String|The date that the serving capacity was last verified/measured. Use the format `dd/mm/yyyy`.|
+|servingCapacityDate|`recommended`|Date|The date that the serving capacity was last verified/measured. Use the format `yyyy-mm-dd` adhering to the [ISO 8601 dateTime standard](https://www.iso.org/iso-8601-date-and-time-format.html).|
 |partOfMultipack|`required`|Boolean|Is the complete packaging part of a multipack? Answer as: `TRUE` for yes and `FALSE` for no.|
 |certification|`recommended`|Boolean|Does the complete packaging have a certificate (e.g. FSC, REACH, FSA etc.)? Answer as: `TRUE` for yes and `FALSE` for no.|
 |certificationClaims|`recommended`|List|The information regarding the certifications. The entries should be the [certification claims relationship list](../6_Relationship_Lists/6_005_Certification_Claims.md) identifiers.|
 |manufacturers|`recommended`|List|The information regarding the manufacturer(s). The entries should be the [Organisations Relationship List](../6_Relationship_Lists/6_010_Organisations.md) identifiers.|
 |manufacturedCountry|`recommended`|Numeric|The country the complete packaging was manufactured and/or combined in. Use the country numeric [ISO codes](https://www.iban.com/country-codes){target=_blank} as described in the ISO 3166 international standard.|
-|updateDate|`required`|String|The date that the complete packaging was provided/last updated. Use the format `dd/mm/yyyy`.|
-|releaseDate|`recommended`|String|The date that the complete packaging will be available to use. Use the format `dd/mm/yyyy`.|
-|discontinueDate|`recommended`|String|The date that the complete packaging will no longer be available to use. Use the format `dd/mm/yyyy`.|
+|updateDate|`required`|Date|The date that the complete packaging was provided/last updated. Use the format `yyyy-mm-dd` adhering to the [ISO 8601 dateTime standard](https://www.iso.org/iso-8601-date-and-time-format.html).|
+|releaseDate|`recommended`|Date|The date that the complete packaging will be available to use. Use the format `yyyy-mm-dd` adhering to the [ISO 8601 dateTime standard](https://www.iso.org/iso-8601-date-and-time-format.html).|
+|discontinueDate|`recommended`|Date|The date that the complete packaging will no longer be available to use. Use the format `yyyy-mm-dd` adhering to the [ISO 8601 dateTime standard](https://www.iso.org/iso-8601-date-and-time-format.html).|
 
 ## Diagram
 
@@ -70,27 +70,27 @@ COMPONENTS }o--o{ COMPLETE_PACKAGING : complete_packaging_constituents
     recyclability Boolean
     recyclabilityClaims List
     height Numeric
-    heightDate String
+    heightDate Date
     width Numeric
-    widthDate String
+    widthDate Date
     depth Numeric
-    depthDate String
+    depthDate Date
     volume Numeric
-    volumeDate String
+    volumeDate Date
     weight Numeric
     weightTolerance Numeric
     weightToleranceType String
-    weightDate String
+    weightDate Date
     servingCapacity Numeric
-    servingCapacityDate String
+    servingCapacityDate Date
     partOfMultipack Boolean
     certification Boolean
     certificationClaims List
     manufacturers List
     manufacturedCountry Numeric
-    updateDate String
-    releaseDate String
-    discontinueDate String
+    updateDate Date
+    releaseDate Date
+    discontinueDate Date
   }
   COMPLETE_PACKAGING }o..o{ CONTROLLED_LISTS : attributes
   COMPLETE_PACKAGING }O..O{ RELATIONSHIP_LISTS : attributes
@@ -152,19 +152,19 @@ Complete packaging should be provided as a separate csv file. The specification 
             "b101889f-87e5-4c42-abb7-0df5fc3d1a26"
         ],
         "height": 220,
-        "heightDate": "01/01/2023",
+        "heightDate": "2023-01-01",
         "width": 170,
-        "widthDate": "01/01/2023",
+        "widthDate": "2023-01-01",
         "depth": 60,
-        "depthDate": "01/01/2023",
+        "depthDate": "2023-01-01",
         "volume": 0.002,
-        "volumeDate": "01/01/2023",
+        "volumeDate": "2023-01-01",
         "weight": 32.8,
         "weightTolerance": 5,
         "weightToleranceType": "percentage",
-        "weightDate": "01/01/2023",
+        "weightDate": "2023-01-01",
         "servingCapacity": 4,
-        "servingCapacityDate": "01/01/2023",
+        "servingCapacityDate": "2023-01-01",
         "partOfMultipack": false,
         "certification": true,
         "certificationClaims": [
@@ -172,8 +172,8 @@ Complete packaging should be provided as a separate csv file. The specification 
         ],
         "manufacturers": [""],
         "manufacturedCountry": 826,
-        "updateDate": "01/01/2023",
-        "releaseDate": "01/01/2023",
+        "updateDate": "2023-01-01",
+        "releaseDate": "2023-01-01",
         "discontinueDate": ""
     }
     ```

--- a/docs/3_Data_Specification/3_5_Multipack.md
+++ b/docs/3_Data_Specification/3_5_Multipack.md
@@ -21,9 +21,9 @@ The multipack schema contains information regarding the multipacks that are used
 |identicalQuantity|`required`|Numeric|Number of identical units for the unique complete packaging item or a component this row corresponds to.|
 |manufacturers|`recommended`|List|The information regarding the manufacturer(s). The entries should be the [Organisations Relationship List](../6_Relationship_Lists/6_010_Organisations.md) identifiers.|
 |manufacturedCountry|`recommended`|Numeric|The country the multipack was manufactured and/or combined. Use the country numeric [ISO codes](https://www.iban.com/country-codes){target=_blank} as described in the ISO 3166 international standard.|
-|updateDate|`required`|String|The date that the multipack was provided/last updated. Use the format `dd/mm/yyyy`.|
-|releaseDate|`recommended`|String|The date that the component will be available to use. Use the format `dd/mm/yyyy`.|
-|discontinueDate|`recommended`|String|The date that the component will no longer be available to use. Use the format `dd/mm/yyyy`.|
+|updateDate|`required`|Date|The date that the multipack was provided/last updated. Use the format `yyyy-mm-dd` adhering to the [ISO 8601 dateTime standard](https://www.iso.org/iso-8601-date-and-time-format.html).|
+|releaseDate|`recommended`|Date|The date that the component will be available to use. Use the format `yyyy-mm-dd` adhering to the [ISO 8601 dateTime standard](https://www.iso.org/iso-8601-date-and-time-format.html).|
+|discontinueDate|`recommended`|Date|The date that the component will no longer be available to use. Use the format `yyyy-mm-dd` adhering to the [ISO 8601 dateTime standard](https://www.iso.org/iso-8601-date-and-time-format.html).|
 
 ## Diagram
 
@@ -42,9 +42,9 @@ COMPLETE_PACKAGING }o..o{ MULTIPACK : multipack_constituents
     identicalQuantity Numeric
     manufacturers List
     manufacturedCountry Numeric
-    updateDate String
-    releaseDate String
-    discontinueDate String
+    updateDate Date
+    releaseDate Date
+    discontinueDate Date
   }
   MULTIPACK }o--o{ RELATIONSHIP_LISTS : attributes
   COMPLETE_PACKAGING }o..o{ LOADS : load_constituents
@@ -79,8 +79,8 @@ Multipack should be provided as a separate csv file. The specification of this c
       "identicalQuantity": "4",
       "manufacturers": [""],
       "manufacturedCountry": 826,
-      "updateDate": "01/08/2022",
-      "releaseDate": "01/08/2022",
+      "updateDate": "2022-08-01",
+      "releaseDate": "2022-08-01",
       "discontinueDate": "",
     }
     ```

--- a/docs/3_Data_Specification/3_6_Load_Catalogue.md
+++ b/docs/3_Data_Specification/3_6_Load_Catalogue.md
@@ -18,7 +18,7 @@ All the complete packaging from different levels (primary, secondary, transit et
 |packagingItems|`required`|List|The complete packaging and/or the multipack identifiers used to create the load. There must be an equivalent record in the `Complete Packaging` or `Multipack` data.|
 |quantityInLoad|`required`|Numeric|Number of units for the packaging items found in a load that this row corresponds to.|
 |level|`required`|String|The intended use of the component for the packaging. The entry here should be drawn from the [level controlled list](../5_Controlled_Lists/5_015_Level.md).|
-|updateDate|`required`|String|The date that the load catalogue was provided/last updated. Use the format `dd/mm/yyyy`.|
+|updateDate|`required`|Date|The date that the load catalogue was provided/last updated. Use the format `yyyy-mm-dd` adhering to the [ISO 8601 dateTime standard](https://www.iso.org/iso-8601-date-and-time-format.html).|
 
 ## Diagram
 
@@ -40,7 +40,7 @@ COMPLETE_PACKAGING }o..o{ MULTIPACK : within
     packagingItems List
     quantityInLoad Numeric
     level String
-    updateDate String
+    updateDate Date
   }
   LOAD_CATALOGUE }o..o{ CONTROLLED_LISTS : attributes
   LOAD_CATALOGUE }o--o{ LOAD : within
@@ -75,7 +75,7 @@ Loads should be provided as a separate csv file. The specification of this csv f
         "category":"primary",
         "detailed":"The individual container that you store goods in to sell to consumers. This is called a "sales unit". For example, if you sell peas in steel tins with paper labels, the primary packaging is "steel tin" and "paper label"."
       },
-      "updateDate": "01/08/2022",
+      "updateDate": "2023-01-01",
     }
     ```
 === "CSV download"

--- a/docs/3_Data_Specification/3_7_Load.md
+++ b/docs/3_Data_Specification/3_7_Load.md
@@ -17,8 +17,8 @@ Note that all core entities can be incorporated into loads. This is to faciliate
 |description|`recommended`|String|A brief description of this load.|
 |externalIdentifiers|`recommended`|Dictionary|A dictionary of identifiers that might be used to identify the load in other systems. For example: manufacturer's own internal identifier, bar codes or global trade item number (gtin). To provide external identifiers please follow this format. `{'externalIdentifierName1': 'identifier1', 'externalIdentifierName2': 'identifier2'}`|
 |loadIdentifiers|`required`|List|The unique identifier of the created load. There must be an equivalent identifier found in the `Load Catalogue`.|
-|startDate|`required`|String|The date that the load began for the destination. Use the format `dd/mm/yyyy`.|
-|endDate|`required`|String|The date that the load ended for the destination. Use the format `dd/mm/yyyy`.|
+|startDate|`required`|Date|The date that the load began for the destination. Use the format `yyyy-mm-dd` adhering to the [ISO 8601 dateTime standard](https://www.iso.org/iso-8601-date-and-time-format.html).|
+|endDate|`required`|Date|The date that the load ended at the destination. Use the format `yyyy-mm-dd` adhering to the [ISO 8601 dateTime standard](https://www.iso.org/iso-8601-date-and-time-format.html).|
 |destinationAddressName|`recommended`|String|The name of the load destination address.|
 |destinationAddressStreet|`required`|String|The street address of this load destination.|
 |destinationAddressCountry|`required`|String|The country of this load destination.|
@@ -26,7 +26,7 @@ Note that all core entities can be incorporated into loads. This is to faciliate
 |timesSent|`required`|Numeric|The number of times this load was sent to the destination during the specified time period.|
 |manufacturers|`recommended`|List|The information regarding the manufacturer(s). The entries should be the [Organisations Relationship List](../6_Relationship_Lists/6_010_Organisations.md) identifiers.|
 |manufacturedCountry|`recommended`|Numeric|The country the load was manufactured and/or combined. Use the country numeric [ISO codes](https://www.iban.com/country-codes){target=_blank} as described in the ISO 3166 international standard.|
-|updateDate|`required`|String|The date that the load was provided/last updated. Use the format `dd/mm/yyyy`.|
+|updateDate|`required`|Date|The date that the load was provided/last updated. Use the format `yyyy-mm-dd` adhering to the [ISO 8601 dateTime standard](https://www.iso.org/iso-8601-date-and-time-format.html).|
 
 ## Diagram
 
@@ -46,7 +46,8 @@ COMPONENTS }o..o{ COMPLETE_PACKAGING : complete_packaging_constituents
     description String
     externalIdentifier Dictionary
     loadIdentifiers List
-    startDate String
+    startDate Date
+    endDate Date
     destinationAddressName String
     destinationAddressStreet String
     destinationAddressCountry String
@@ -54,7 +55,7 @@ COMPONENTS }o..o{ COMPLETE_PACKAGING : complete_packaging_constituents
     timesSent Numeric
     manufacturers List
     manufacturedCountry Numeric
-    updateDate String
+    updateDate Date
   }
   LOADS }o--o{ RELATIONSHIP_LISTS : attributes
   RELATIONSHIP_LISTS {
@@ -81,8 +82,8 @@ Loads should be provided as a separate csv file. The specification of this csv f
         "GTIN":"00123456789012",
         },
       "loadIdentifiers": "CA88F5CE-2D09-AFE0-08D7-44804780F924",
-      "startDate": "01/08/2022",
-      "endDate": "01/08/2022",
+      "startDate": "2023-01-01",
+      "endDate": "2023-01-01",
       "destinationAddressName": "Example Company",
       "destinationAddressStreet": "High Street West",
       "destinationAddressCountry": "England",
@@ -90,7 +91,7 @@ Loads should be provided as a separate csv file. The specification of this csv f
       "timesSent": "2",
       "manufacturers": [""],
       "manufacturedCountry": 826,
-      "updateDate": "01/08/2022",
+      "updateDate": "2022-08-01",
     }
     ```
 === "CSV download"

--- a/docs/6_Relationship_Lists/6_005_Certification_Claims.md
+++ b/docs/6_Relationship_Lists/6_005_Certification_Claims.md
@@ -17,7 +17,7 @@ The Certification Claims relationship list identifies the certificates that can 
 |:-|:-|:-|:-|
 |certificationIdentifier|`required`|String|A globally unique identifier. See [identifiers](../4_Identifiers/4_1_Identifiers.md) section for information on how to construct this identifier|
 |certificationSource|`required`|String|What source provided the certificate? The entry should be the [Certification Source Controlled List](../5_Controlled_Lists/5_002_Certification_Source.md) identifier.|
-|certificationIssueDate|`recommended`|String|The date that the certificate was provided/last updated. Use the format `dd/mm/yyyy`.|
+|certificationIssueDate|`recommended`|Date|The date that the certificate was provided/last updated. Use the format `yyyy-mm-dd` adhering to the [ISO 8601 dateTime standard](https://www.iso.org/iso-8601-date-and-time-format.html).|
 
 ## Diagram
 
@@ -30,7 +30,7 @@ erDiagram
   CERTIFICATION_CLAIMS {
     certificationIdentifier String
     certificationSource String
-    certificationIssueDate String
+    certificationIssueDate Date
   }
   CERTIFICATION_CLAIMS }o--o{ CONTROLLED_LISTS : attributes
   CONTROLLED_LISTS {
@@ -53,7 +53,7 @@ Certification claims should be provided as a separate csv file. The specificatio
     {
       "certificationIdentifier": "eed87ac3-6e3e-45fb-af2c-dd0f64fdb597",
       "certificationSource": "certification-source-0002",
-      "certificationIssueDate": "01/08/2022"
+      "certificationIssueDate": "2022-08-01"
     }
     ```
 

--- a/docs/6_Relationship_Lists/6_006_Recyclability_Claims.md
+++ b/docs/6_Relationship_Lists/6_006_Recyclability_Claims.md
@@ -15,7 +15,7 @@ The recyclability claims relationship list identifies organisations and schemes 
 |:-|:-|:-|:-|
 |recyclabilityIdentifier|`required`|String|A globally unique identifier. See [identifiers](../4_Identifiers/4_1_Identifiers.md) section for information on how to construct this identifier|
 |recyclabilitySource|`recommended`|String|What source provided the certificate? The entry should be the [recyclability source controlled list](../5_Controlled_Lists/5_005_Recyclability_Source.md) identifier.|
-|recyclabilityIssueDate|`recommended`|String|The date that the certificate was provided/last updated. Use the format `dd/mm/yyyy`.|
+|recyclabilityIssueDate|`recommended`|Date|The date that the certificate was provided/last updated. Use the format `yyyy-mm-dd` adhering to the [ISO 8601 dateTime standard](https://www.iso.org/iso-8601-date-and-time-format.html).|
 
 ## Diagram
 
@@ -27,7 +27,7 @@ erDiagram
   RECYCLABILITY_CLAIMS {
     recyclabilityIdentifier String
     recyclabilitySource String
-    recyclabilityIssueDate String
+    recyclabilityIssueDate Date
   }
   RECYCLABILITY_CLAIMS }o--o{ CONTROLLED_LISTS : attributes
   CONTROLLED_LISTS {
@@ -50,6 +50,6 @@ Recyclability claims should be provided as a separate csv file. The specificatio
     {
       "recyclabilityIdentifier": "b101889f-87e5-4c42-abb7-0df5fc3d1a26",
       "recyclabilitySource": "recyclability-source-0001",
-      "recyclabilityIssueDate": "01/08/2022"
+      "recyclabilityIssueDate": "2022-08-01"
     }
     ```

--- a/docs/6_Relationship_Lists/6_009_Recycled_Content_Claims.md
+++ b/docs/6_Relationship_Lists/6_009_Recycled_Content_Claims.md
@@ -13,7 +13,7 @@ The recycled content claims relationship list identifies the document that detai
 |recycledContentIdentifier|`required`|String|A globally unique identifier. See [identifiers](../4_Identifiers/4_1_Identifiers.md) section for information on how to construct this identifier|
 |recycledContentEvidenceType|`recommended`|String|What type of document provides the information regarding the claim? The entry should be the [recycled content evidence type](../5_Controlled_Lists/5_011_Recycled_Content_Evidence_Type.md) identifier.|
 |recycledContentEvidenceReference|`recommended`|String|An accompanying reference number associated with the recycled content evidence type for the component.|
-|recycledContentIssueDate|`recommended`|String|The date that the recycled content evidence was issued. Use the format `dd/mm/yyyy`.|
+|recycledContentIssueDate|`recommended`|Date|The date that the recycled content evidence was issued. Use the format `yyyy-mm-dd` adhering to the [ISO 8601 dateTime standard](https://www.iso.org/iso-8601-date-and-time-format.html).|
 
 ## Diagram
 
@@ -25,7 +25,7 @@ erDiagram
     recycledContentIdentifier String
     recycledContentEvidenceType String
     recycledContentEvidenceReference String
-    recycledContentIssueDate String
+    recycledContentIssueDate Date
   }
   RECYCLED_CONTENT_CLAIMS }o--o{ CONTROLLED_LISTS : attributes
   CONTROLLED_LISTS {
@@ -49,6 +49,6 @@ Recycled content claims should be provided as a separate csv file. The specifica
       "recycledContentIdentifier": "23e8251a-4fe6-4b25-9966-b08acac9ba34",
       "recycledContentEvidenceType": "c-recycled-evidence-0001",
       "recycledContentEvidenceReference": "ABC-123-Example",
-      "recycledContentIssueDate": "01/08/2022"
+      "recycledContentIssueDate": "2022-08-01"
     }
     ```

--- a/docs/9_Change_Log/8_1_Change_Log.md
+++ b/docs/9_Change_Log/8_1_Change_Log.md
@@ -6,6 +6,11 @@ title: Latest Updates
 # Latest Updates
 A document that contains all the changes made to the standard.
 
+## November 30, 2023
+### Documents
+ - Changed ALL date related fields to ISO 8601 standard, changed the format to `Date`.
+ - Updated ALL JSON dates to read as `yyyy-mm-dd`. 
+
 ## November 23, 2023
 ### Documents
  - Reworked data diagrams to show the constituents lists as the edges between the tables.


### PR DESCRIPTION
Changed format for all date fields from String to Date

Changed all descriptions relating to dates to include ISO 8601 text and link.

Changed all JSON examples to be yyyy-mm-dd and not dd/mm/yyyy