### PR TITLE
Changed multipack constituents text

### DIFF
--- a/docs/6_Relationship_Lists/6_004_Multipack_Constituents.md
+++ b/docs/6_Relationship_Lists/6_004_Multipack_Constituents.md
@@ -5,7 +5,7 @@ description: The multipack constituents relationship list.
 
 # Multipack Constituents
 
-The multipack constituents relationship list identifies the complete packaging items that are combined to create multipacks. This is only used in [multipack](../3_Data_Specification/3_5_Multipack.md).
+The multipack constituents relationship list identifies the complete packaging items and components that are combined to create multipacks. This is only used in [multipack](../3_Data_Specification/3_5_Multipack.md).
 
 ## Data
 |Column|<div style="width:90px">Status</div>|Format|Notes|


### PR DESCRIPTION
Changed to 

> The multipack constituents relationship list identifies the complete packaging items and components that are combined to create multipacks. This is only used in multipack.