### PR TITLE
Change loadCombinationIdentifier wording

### DIFF
--- a/docs/6_Relationship_Lists/6_011_Load_Constituents.md
+++ b/docs/6_Relationship_Lists/6_011_Load_Constituents.md
@@ -11,7 +11,7 @@ The loads constituents relationship list identifies the all the complete packagi
 |Column|<div style="width:90px">Status</div>|Format|Notes|
 |:-|:-|:-|:-|
 |loadConstituentsIdentifier|`mandatory`|UUID|A globally unique identifier. See [identifiers](../4_Identifiers/4_1_Identifiers.md) section for information on how to construct this identifier|
-|loadCombinationIdentifier|`mandatory`|UUID|The unique identifier of the items that this component is made of. There must be an equivalent record in the `Complete_Packaging` OR `Multipacks` data.|
+|loadCombinationIdentifier|`mandatory`|UUID|The unique identifier of the items that this component is made of. There must be an equivalent record in the `Base_Materials`, `Materials`, `Components`, `Complete_Packaging` OR `Multipacks` data.|
 |name|`optional`|String|The name of this load constituent.|
 |externalIdentifiers|`optional`|Dictionary|A dictionary of identifiers that might be used to identify the load constituents in other systems. For example: manufacturer's own internal identifier, bar codes or global trade item number (gtin). To provide external identifiers please follow this format. `{'externalIdentifierName1': 'identifier1', 'externalIdentifierName2': 'identifier2'}`|
 |quantityInLoad|`mandatory`|Integer|Number of units for the packaging items found in a load that this row corresponds to.|


### PR DESCRIPTION
Changed wording to 

> The unique identifier of the items that this component is made of. There must be an equivalent record in the `Base_Materials`, `Materials`, `Components`, `Complete_Packaging` OR `Multipacks` data.